### PR TITLE
Generic clean up + Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,18 @@
 language: node_js
 node_js:
-    - "0.10"
-    - "0.12"
+    - 0.1
+    - 0.12
+notifications:
+    email:
+        recipients:
+            - ypt-team@yahoo-inc.com
+        on_success: change
+        on_failure: always
+deploy:
+    provider: npm
+    email: ypt-team@yahoo-inc.com
+    api_key: 
+        secure: s5KbfZ2QmDElovpw8PZYFwiwYIcvmORO1dpnsbSpuNrdgW/vr79vxmETg1RdaTOC+eprtJgf3DkqBeuUeavc2S9ksO9sbryhL48Sfu3wQBQWIfana6H1weVpHxUfS4TU9bT2zRlxRDQsYuFmmtacaJ0DpDKrnpdpVBgXxKJWq4o=
+    on:
+        tags: true
+        all_branches: true

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ API
 var csp = require('express-csp');
 
 var app = express();
+
 csp.extend(app, {
     policy: {
         directives: {
@@ -50,7 +51,7 @@ When set to true, a [`nonce`](http://w3c.github.io/webappsec/specs/content-secur
 
 When set to true, a [`nonce`](http://w3c.github.io/webappsec/specs/content-security-policy/#script-src-the-nonce-attribute) will be generated for the `'style-src'` directive of each response and made available as the `res.locals.cspToken` value. This value can then be used in your templates to allow for specified inline script and style blocks. If [`useScriptNonce`](#useScriptNonce) is also true, the same token will be added to the `'script-src'` directive and the same token will be available for inline script blocks.
 
-```js
+```html
 <script nonce="{{res.locals.cspToken}}">
 foo();
 </script>
@@ -90,7 +91,7 @@ app.signScript('foo();');
 ```
 
 Enables `foo();` throughout the app
-```js
+```html
 <script>foo();</script>
 ```
 At the response level
@@ -100,12 +101,12 @@ app.route('/').get(function (req, res) {
 });
 ```
 Enables `bar();` for the route only.
-```js
+```html
 <script>bar();</script>
 ```
 
 These will not work with the above examples.
-```js
+```html
 <script>
 foo();
 </script>
@@ -132,7 +133,7 @@ app.route('/').get(function (req, res) {
 ### res.setPolicy
 Allows policy to be set per request. The app level policy set in `extend` will be ignored when `res.setPolicy` is used. This method takes the same config object as the `extend` method.
 
-```
+```js
 app.get('/', function(req, res, next) {
     res.setPolicy({
         policy: {

--- a/index.js
+++ b/index.js
@@ -5,308 +5,140 @@
  */
 
 'use strict';
-var crypto = require('crypto');
-var LRU    = require('lru-cache');
 
-exports.extend = function (app, config) {
-    var VALID_DIRECTIVES = [
-        'default-src',
-        'style-src',
-        'connect-src',
-        'script-src',
-        'object-src',
-        'img-src',
-        'frame-ancestors',
-        'form-action',
-        'child-src',
-        'base-uri',
-        'media-src',
-        'font-src',
-        'plugin-types',
-        'report-uri'
-    ];
+var onHeaders = require('on-headers');
+var CSP       = require('./lib/csp');
 
-    var TOKEN_RE = /(self|unsafe-inline)(?!.)|(sha(256|384|512)-|nonce-)/;
+function policyBuilder (policy, signedScripts, signedStyles) {
+    var hasSignedScripts = signedScripts.length > 0;
+    var hasSignedStyles  = signedStyles.length > 0;
+    var useScriptNonce   = !!policy.useScriptNonce;
+    var useStyleNonce    = !!policy.useStyleNonce;
+    var directives       = policy.directives || {};
+    var nonce            = (useScriptNonce || useStyleNonce) ? '\'nonce-' + this.locals.cspToken + '\' ' : null;
+    var directiveKeys    = Object.keys(directives);
+    var typePolicy;
 
-    var cache  = new LRU(50);
-    var appSignedScripts = {};
-    var appSignedStyles = {};
-    var cspPolicies;
-    
-    if (app['@express-csp']) {
-        return;
+    if ((useScriptNonce || hasSignedScripts) && directiveKeys.indexOf('script-src') < 0) {
+        directiveKeys.push('script-src');
     }
 
-    Object.defineProperty(app, '@express-csp', {
+    if ((useStyleNonce || hasSignedStyles) && directiveKeys.indexOf('style-src') < 0) {
+        directiveKeys.push('style-src');
+    }
+
+    return directiveKeys.map(function (type) {
+        typePolicy = [type].concat(directives[type] || []);
+
+        if ((useScriptNonce && type === 'script-src') || (useStyleNonce && type === 'style-src')) {
+            typePolicy = typePolicy.concat(nonce);
+        }
+
+        if (type === 'script-src' && hasSignedScripts) {
+            typePolicy = typePolicy.concat(signedScripts);
+        }
+        else if (type === 'style-src' && hasSignedStyles) {
+            typePolicy = typePolicy.concat(signedStyles);
+        }
+
+        return typePolicy.join(' ');
+    }).join(';');
+}
+
+exports.extend = function (app, config) {
+    if (app['@csp']) { return app; }
+
+    Object.defineProperty(app, '@csp', {
         value: exports
     });
 
-    config = config || {};
-    cspPolicies = getCSPPolicies(config);
+    var csp = new CSP(config);
 
-    function sign(str) {
-        var result = cache.get(str),
-            hash;
-
-        if (!result) {
-            // The hashing algorithm may be one of: SHA-256, SHA-384 or SHA-512
-            // See https://w3c.github.io/webappsec/specs/content-security-policy/#source-list-valid-hashes
-            // Node only supports SHA-256 and SHA-512. Using the 256 version
-            // because it's faster.
-            hash = crypto.createHash('sha256');
-            hash.update(str, 'utf8');
-            // As per the spec in 4.2.5.2.3, this must return the base64 encoded
-            // version of the digest
-            result = 'sha256-' + hash.digest('base64');
-            cache.set(str, result);
-        }
-
-        return result;
-    }
-
-    //creates an array of hashes from an object containing hashes as key values
-    function unsafeGetProps(obj) {
-        var hashes = [], hash;
-
-        // Ignore hasOwnProperty because this function is meant to be called
-        // on objects created with Object.create(null)
-        /*jshint forin: false*/
-        for (hash in obj) {
-            hashes.push('\'' + hash + '\'');
-        }
-
-        return hashes;
-        /*jshint forin: true*/
-    }
-
-    function getHeaders(res, policy, signedScripts, signedStyles) {
-        var useSignedScripts = signedScripts.length > 0,
-            useSignedStyles = signedStyles.length > 0,
-            directives = policy.directives || {},
-            policies,
-            useScriptNonce = policy.useScriptNonce,
-            useStyleNonce = policy.useStyleNonce,
-            nonce = (useScriptNonce || useStyleNonce) ? '\'nonce-' + res.locals.cspToken + '\' ' : null,
-            policyKeys = Object.keys(directives);
-        
-        if ((useScriptNonce || useSignedScripts) && policyKeys.indexOf('script-src') < 0) {
-            policyKeys.push('script-src');
-        }
-        
-        if ((useStyleNonce || useSignedStyles) && policyKeys.indexOf('style-src') < 0) {
-            policyKeys.push('style-src');
-        }
-
-        policies = policyKeys.map(function (type) {
-            var policy = [type].concat(directives[type] || []);
-
-            if ((useScriptNonce && type === 'script-src') || (useStyleNonce && type === 'style-src')) {
-                policy = policy.concat(nonce);
-            }
-
-            if (type === 'script-src' && useSignedScripts) {
-                policy = policy.concat(signedScripts);
-            }
-
-            if (type === 'style-src' && useSignedStyles) {
-                policy = policy.concat(signedStyles);
-            }
-            
-            policy = policy.join(' ');
-            return policy;
-        });
-
-        return policies.join(';');
-    }
-
-    function setHeaders(res) {
-        var signedScripts = unsafeGetProps(getSignedScripts(res)),
-            signedStyles = unsafeGetProps(getSignedStyles(res)),
-            responsePolicies = res.locals.cspPolicies,
-            policies = responsePolicies ? responsePolicies.policy : cspPolicies.policy,
-            reportPolicies = responsePolicies ? responsePolicies.reportPolicy : cspPolicies.reportPolicy,
-            policy,
-            reportPolicy;
-
-        if (policies) {
-            policy = getHeaders(res, policies, signedScripts, signedStyles);
-            res.setHeader('Content-Security-Policy', policy);
-        }
-
-        if (reportPolicies) {
-            reportPolicy = getHeaders(res, reportPolicies, signedScripts, signedStyles);
-            res.setHeader('Content-Security-Policy-Report-Only', reportPolicy);
-        }
-    }
-
-    // Signed scripts are stored as keys in an object to take advantage of
-    // prototypical inheritance instead of relying on array concatenation
-    // This way getting all the signed scripts just means getting all the
-    // properties of the response._cspSignedScripts object
-    function getSignedScripts(res) {
-        if (!res._cspSignedScripts) {
-            Object.defineProperty(res, '_cspSignedScripts', {
-                value: Object.create(appSignedScripts)
-            });
-        }
-        return res._cspSignedScripts;
-    }
-
-    // Signed styles are stored as keys in an object to take advantage of
-    // prototypical inheritance instead of relying on array concatenation
-    // This way getting all the signed styles just means getting all the
-    // properties of the response._cspSignedStyles object
-    function getSignedStyles(res) {
+    function getSignedStyles (res) {
         if (!res._cspSignedStyles) {
             Object.defineProperty(res, '_cspSignedStyles', {
-                value: Object.create(appSignedStyles)
+                value: Object.create(csp.styles)
             });
         }
+
         return res._cspSignedStyles;
     }
 
-    //Deep copy of data structure to prevent future mutations which could
-    //cause an unintentional change to the headers.
-    //Checking for nonce sources at the app level. Nonces should not be
-    //explicitly set at app creation. Nonces should be randomly generated
-    //per request. If you need to use a nonce for inline scripts, set the
-    //`useScriptNonce`  or `useStyleNonce` value to true.
-    function getCSPPolicies(config) {
-        var policy,
-            reportPolicy;
-        if (config.policy) {
-            policy = Object.freeze({
-                useScriptNonce: config.policy.useScriptNonce || false,
-                useStyleNonce: config.policy.useStyleNonce || false,
-                directives: config.policy.directives ? getDirectives(config.policy.directives) : null
+    function getSignedScripts (res) {
+        if (!res._cspSignedScripts) {
+            Object.defineProperty(res, '_cspSignedScripts', {
+                value: Object.create(csp.scripts)
             });
         }
-        if (config.reportPolicy) {
-            reportPolicy = Object.freeze({
-                useScriptNonce: config.reportPolicy.useScriptNonce || false,
-                useStyleNonce: config.reportPolicy.useStyleNonce || false,
-                directives: config.reportPolicy.directives ? getDirectives(config.reportPolicy.directives) : null
-            });
-        }
-        return Object.freeze({
-            policy: policy,
-            reportPolicy: reportPolicy
-        });
+
+        return res._cspSignedScripts;
     }
 
-    function getDirectives(config) {
-        var directives = {};
-        VALID_DIRECTIVES.forEach(function (directiveName) {
-            if (Array.isArray(config[directiveName])) {
-                directives[directiveName] = config[directiveName].filter(function (rule) {
-                    //If cspPolicies have been defined, no app level directives can be set
-                    //i.e. this is a request and it is safe to allow the developer to specify
-                    //a nonce
-                    if (cspPolicies || rule.replace(/\'/, '').indexOf('nonce-') !== 0) {
-                        return true;
-                    }
-                    throw new Error('You cannot explicitly set a nonce at the app level. If you want to use a nonce, set `useScriptNonce` or `useStyleNonce` to true in the config object.');
-                })
-                .map(function (rule) {
-                    if(TOKEN_RE.test(rule)) {
-                        rule = '\'' + rule + '\'';
-                    }
-                    return rule;
-                });
-                Object.freeze(directives[directiveName]);
-            }
-        });
-        return Object.freeze(directives);
-    }
+    app.signScript = function (str) {
+        csp.signScript(str);
+    };
 
-    function setNonce(res, appPolicies, appReportPolicies, callback) {
-        if ((appPolicies && (appPolicies.useScriptNonce || appPolicies.useStyleNonce)) ||
-            (appReportPolicies && (appReportPolicies.useScriptNonce || appReportPolicies.useStyleNonce))) {
-            // Using base64 encoding, assuming the character set is the one defined
-            // in http://en.wikipedia.org/wiki/Base64#Examples. This should base a
-            // safe value for HTML attributes and HTTP headers.
-            createToken(36, 'base64', function (err, token) {
-                if (err) {
-                    return callback(err);
-                }
-                try {
-                    Object.defineProperty(res.locals, 'cspToken', {
-                        value: token,
-                        enumerable: true
-                    });
-                    callback(null, res);
-                } catch(e) {
-                    callback(new Error('Unable to set the nonce token to res.locals.'));
-                }
-            });
-        } else {
-            callback(null, res);
-        }
-    }
-
-    // middleware
-    app.use(function (req, res, next) {
-        setNonce(res, cspPolicies.policy, cspPolicies.reportPolicy, function(err, res) {
-            if (err) {
-                next(err);    
-            }
-            setHeaders(res);
-            next();
-        });
-    });
-
-
-    app.signScript = function (script) {
-        appSignedScripts[sign(script)] = true;
+    app.signStyle = function (str) {
+        csp.signStyle(str);
     };
 
     app.response.signScript = function (script) {
         var scripts = getSignedScripts(this);
-        scripts[sign(script)] = true;
-        setHeaders(this);
-    };
-
-    app.signStyle = function (style) {
-        appSignedStyles[sign(style)] = true;
+        scripts[csp.sign(script)] = true;
     };
 
     app.response.signStyle = function (style) {
         var styles = getSignedStyles(this);
-        styles[sign(style)] = true;
-        setHeaders(this);
+        styles[csp.sign(style)] = true;
     };
 
     app.response.setPolicy = function (config) {
-        Object.freeze(config);
-        var policy = config.policy,
-            reportPolicy = config.reportPolicy;
         try {
-            Object.defineProperty(this.locals, "cspPolicies", {
-                value: getCSPPolicies(config),
+            Object.defineProperty(this.locals, 'cspPolicies', {
+                value:      csp.parseConfiguration(config),
                 enumerable: true
             });
-        } catch(e) {
-            throw new Error('The res.locals.cspPolicies value must only be set once per request and must always be set through the `setPolicy` method.');
-        }
-        if (this.locals.cspToken) {
-            setHeaders(this);
-        } else {
-            setNonce(this, policy, reportPolicy, function(err, res) {
-                if (err) {
-                    throw err;    
-                }
-                setHeaders(res);
-            });
+        } catch (ex) {
+            throw new Error('The `response.locals.cspPolicies` value must only be set once per request and must always be set through the `setPolicy` method.');
         }
     };
 
-    function createToken(length, encoding, callback) {
-        return crypto.pseudoRandomBytes(length, function(err, token) {
-            if (err) {
-                callback(err);
-            } else {
-                callback(null, token.toString(encoding));
+    app.use(function (req, res, next) {
+        var policy       = csp.policies.policy;
+        var reportPolicy = csp.policies.reportPolicy;
+
+        onHeaders(res, function () {
+            var scriptKeys     = csp.getKeys(getSignedScripts(res));
+            var styleKeys      = csp.getKeys(getSignedStyles(res));
+            var localPolicies  = res.locals.cspPolicies;
+            var policies       = localPolicies ? localPolicies.policy : policy;
+            var reportPolicies = localPolicies ? localPolicies.reportPolicy : reportPolicy;
+            var policyHeader, reportPolicyHeader;
+
+            if (policies) {
+                policyHeader = policyBuilder.call(res, policies, scriptKeys, styleKeys);
+                res.setHeader('Content-Security-Policy', policyHeader);
+            }
+
+            if (reportPolicies) {
+                reportPolicyHeader = policyBuilder.call(res, reportPolicies, scriptKeys, styleKeys);
+                res.setHeader('Content-Security-Policy-Report-Only', reportPolicyHeader);
             }
         });
-    }
+
+        /**
+        * Generates a base64 encoded token and stores a nonce token on `res.locals.cspToken`.
+        */
+        if ((policy && (policy.useScriptNonce || policy.useStyleNonce)) ||
+            (reportPolicy && (reportPolicy.useScriptNonce || reportPolicy.useStyleNonce))) {
+            Object.defineProperty(res.locals, 'cspToken', {
+                value:      csp.createNonceToken(),
+                enumerable: true
+            });
+        }
+
+        next();
+    });
+
+    return app;
 };

--- a/lib/csp.js
+++ b/lib/csp.js
@@ -1,0 +1,159 @@
+/*
+ * Copyright (c) 2015, Yahoo Inc. All rights reserved.
+ * Copyrights licensed under the New BSD License.
+ * See the accompanying LICENSE file for terms.
+ */
+
+'use strict';
+
+module.exports = CSP;
+
+var LRU     = require('lru-cache');
+var crypto  = require('crypto');
+var TOKEN_RE = /(self|unsafe-inline)(?!.)|(sha(256|384|512)-|nonce-)/;
+
+if (!Object.assign) {
+    Object.assign = require('object-assign');
+}
+
+var SUPPORTED_DIRECTIVES = [
+    'base-uri',
+    'child-src',
+    'connect-src',
+    'default-src',
+    'font-src',
+    'form-action',
+    'frame-ancestors',
+    'img-src',
+    'media-src',
+    'object-src',
+    'plugin-types',
+    'report-uri',
+    'reflected-xss',
+    'script-src',
+    'style-src'
+];
+
+var freeze = Object.freeze;
+
+function CSP (config) {
+    config = Object.assign({}, config, {
+        cacheSize: 50
+    });
+
+    this.scripts  = {};
+    this.styles   = {};
+    this.cache    = new LRU(config.cacheSize);
+    this.policies = this.parseConfiguration(config);
+}
+
+CSP.prototype = {
+    constructor: CSP,
+    
+    signScript: function (script) {
+        this.scripts[this.sign(script)] = true;
+    },
+
+    signStyle: function (style) {
+        this.styles[this.sign(style)] = true;
+    },
+
+    sign: function (key) {
+        var result = this.cache.get(key);
+        var hash;
+
+        if (!result) {
+            // The hashing algorithm may be one of: SHA-256, SHA-384 or SHA-512
+            // See https://w3c.github.io/webappsec/specs/content-security-policy/#source-list-valid-hashes
+            // Node only supports SHA-256 and SHA-512. Using the 256 version
+            // because it's faster.
+            hash = crypto.createHash('sha256');
+            hash.update(key, 'utf8');
+            // As per the spec in 4.2.5.2.3, this must return the base64 encoded
+            // version of the digest
+            result = 'sha256-' + hash.digest('base64');
+            this.cache.set(key, result);
+        }
+
+        return result;
+    },
+
+    /**
+    * Parses an input object for CSP configurations object
+    * for both `policy`, `reportPolicy` options.
+    *
+    * @method parseConfiguration
+    * @param {Object} CSP Policy Configuration
+    * @return {Object} Parsed CSP Result (immutable)
+    */
+    parseConfiguration: function (config) {
+        var policy, reportPolicy;
+
+        if (config.policy) {
+            policy = freeze({
+                useScriptNonce: !!config.policy.useScriptNonce,
+                useStyleNonce:  !!config.policy.useStyleNonce,
+                directives:     config.policy.directives ? this.getDirectives(config.policy.directives) : null
+            });
+        }
+
+        if (config.reportPolicy) {
+            reportPolicy = freeze({
+                useScriptNonce: !!config.reportPolicy.useScriptNonce,
+                useStyleNonce:  !!config.reportPolicy.useStyleNonce,
+                directives:     config.reportPolicy.directives ? this.getDirectives(config.reportPolicy.directives) : null
+            });
+        }
+
+        return freeze({
+            policy:       policy,
+            reportPolicy: reportPolicy
+        });
+    },
+
+    getDirectives: function (config) {
+        var directives = {};
+
+        SUPPORTED_DIRECTIVES.forEach(function (directiveName) {
+            if (Array.isArray(config[directiveName])) {
+                directives[directiveName] = config[directiveName].filter(function (rule) {
+                    //If policies have been defined, no app level directives can be set
+                    //i.e. this is a request and it is safe to allow the developer to specify
+                    //a nonce
+                    if (this.policies || rule.replace(/\'/, '').indexOf('nonce-') !== 0) {
+                        return true;
+                    }
+                    throw new Error('You cannot explicitly set a nonce at the app level. If you want to use a nonce, set `useScriptNonce` or `useStyleNonce` to true in the config object.');
+                }, this)
+                .map(function (rule) {
+                    if (TOKEN_RE.test(rule)) {
+                        rule = '\'' + rule + '\'';
+                    }
+                    return rule;
+                });
+                freeze(directives[directiveName]);
+            }
+        }, this);
+
+        return freeze(directives);
+    },
+
+    createNonceToken: function () {
+        return crypto.pseudoRandomBytes(36).toString('base64');
+    },
+
+    getKeys: function (obj) {
+        var hashes = [];
+        var hash;
+
+        // Ignore hasOwnProperty because this function is meant to be called
+        // on objects created with Object.create(null)
+        /*jshint forin: false*/
+        for (hash in obj) {
+            hashes.push("'" + hash + "'");
+        }
+
+        return hashes;
+        /*jshint forin: true*/
+    }
+};

--- a/package.json
+++ b/package.json
@@ -2,10 +2,10 @@
   "name": "express-csp",
   "version": "0.0.0",
   "description": "Express middleware that simplifies using Content Security Policy",
-    "licenses": [
+  "licenses": [
     {
-      "type" : "BSD",
-      "url" : "https://github.com/yahoo/express-csp/blob/master/LICENSE"
+      "type": "BSD",
+      "url": "https://github.com/yahoo/express-csp/blob/master/LICENSE"
     }
   ],
   "main": "index.js",
@@ -30,10 +30,11 @@
     "istanbul": "~0.3.6",
     "jshint": "^2.6.0",
     "mocha": "^2.1.0",
-    "object-assign": "~1.0.0",
     "supertest": "~0.15.0"
   },
   "dependencies": {
-    "lru-cache": "~2.5.0"
+    "lru-cache": "~2.5.0",
+    "object-assign": "~1.0.0",
+    "on-headers": "^1.0.0"
   }
 }


### PR DESCRIPTION
Previously it was all scoped within the app.extend making it difficult to unit test.
- [x] header only ever written once (`onHeader` emits an event on `res.writeHeader`)
- [x] Add travis.yml
- [x] Reduce the number of methods hanging off `app.response`
  - We only should be exposing the public methods here
- [x] Whitespacing and renaming symbols

/cc @caridy ready for another review
