### PR TITLE
Update csp directives

### DIFF
--- a/lib/csp.js
+++ b/lib/csp.js
@@ -18,20 +18,25 @@ if (!Object.assign) {
 
 var SUPPORTED_DIRECTIVES = [
     'base-uri',
+    'block-all-mixed-content',
     'child-src',
     'connect-src',
     'default-src',
     'font-src',
     'form-action',
     'frame-ancestors',
+    'frame-src',
     'img-src',
     'media-src',
     'object-src',
     'plugin-types',
     'report-uri',
     'reflected-xss',
+    'require-sri-for',
     'script-src',
-    'style-src'
+    'style-src',
+    'upgrade-insecure-requests',
+    'worker-src'
 ];
 
 var freeze = Object.freeze;


### PR DESCRIPTION
- `frame-src` should be allowed as it's needed for those browsers that support only CSP 1. Another justification is that in CSP 3 draft, `child-src` will be broken into `frame-src` and `worker-src`. i.e., `frame-src` will no longer be deprecated as in CSP 2. This will fix https://github.com/yahoo/express-csp/issues/11
- also added other directives except those CSP 3 ones that are still in draft. https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy#Specifications

@ericf @jlecomte @juandopazo 